### PR TITLE
Update to use latest psycopg2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,12 @@ FROM ubuntu:14.04.4
 RUN apt-get update && apt-get install -y \
     apache2 \
     libapache2-mod-wsgi-py3 \
+    libpq-dev \
     python3.4 \
     python3-pip \
     python3-psycopg2
 
+RUN pip3 install -U psycopg2
 RUN a2enmod wsgi
 
 # Make python point to python3


### PR DESCRIPTION
Ensure we use a newer psycopg2 to take advantage of postgres extensions in django 1.9.

`libpq-dev` in particular allows installing psycopg 2.6 without raising this issue:

```
Error: pg_config executable not found.
```

Please review @alexcouper 
